### PR TITLE
squash assignment show modal close via background click bug

### DIFF
--- a/app/assets/javascripts/gradebook_app/controllers/assignments/assignment_show_ctrl.js
+++ b/app/assets/javascripts/gradebook_app/controllers/assignments/assignment_show_ctrl.js
@@ -1,5 +1,12 @@
 Gradebook.controller("AssignmentShowCtrl", ["$scope", "course", "assignment", "GPAService", "close", "AssignmentService", "CurveService", "$rootScope", "students", "VisualService", function($scope, course, assignment, GPAService, close, AssignmentService, CurveService, $rootScope, students, VisualService) {
 
+  this.closeModal = function () {
+    close(null, 200);
+    this.closed = true;
+  }
+
+  $scope.closed = false;
+
   $scope.assignment = assignment
   $scope.gpa = {}
   $scope.gpa.raw = GPAService.rawGPA(course, assignment)
@@ -84,6 +91,7 @@ Gradebook.controller("AssignmentShowCtrl", ["$scope", "course", "assignment", "G
 
   $scope.close = function(result) {
     close(result, 200)
+    $scope.closed = true;
   }
 
   $scope.addCurve = function() {

--- a/app/assets/javascripts/gradebook_app/controllers/courses/course_show_ctrl.js
+++ b/app/assets/javascripts/gradebook_app/controllers/courses/course_show_ctrl.js
@@ -218,6 +218,12 @@ Gradebook.controller('CourseShowCtrl', ['$scope', 'course', "StudentService", "A
         students: $scope.students
       }
     }).then(function(modal) {
+
+      modal.element.one('hidden.bs.modal', function () {
+        if (!modal.controller.closed) {
+          modal.controller.closeModal();
+        }
+      });
       modal.element.modal();
       modal.close.then(function(response) {
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,13 +223,4 @@ ActiveRecord::Schema.define(version: 20161019210654) do
     t.index ["reset_password_token"], name: "index_teachers_on_reset_password_token", unique: true, using: :btree
   end
 
-  create_table "testers", force: :cascade do |t|
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-    t.string   "avatar_file_name"
-    t.string   "avatar_content_type"
-    t.integer  "avatar_file_size"
-    t.datetime "avatar_updated_at"
-  end
-
 end


### PR DESCRIPTION
Previously, clicking on the background of an assignment show modal would only close the modal visually, without running callbacks. This PR adds an event to the close promise of the modal that makes sure it's closed every time. 
